### PR TITLE
 Copy over task-queue and mock-operators from avs-toolkit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "lavs-apis"
 version = "0.1.0"
-source = "git+https://github.com/Lay3rLabs/avs-toolkit?tag=v0.1.2#bdc342892a3115711a61b7cf206ce7c529cb22e0"
+source = "git+https://github.com/Lay3rLabs/avs-toolkit.git?tag=v0.1.2#bdc342892a3115711a61b7cf206ce7c529cb22e0"
 dependencies = [
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
@@ -1164,7 +1164,7 @@ dependencies = [
 [[package]]
 name = "lavs-helpers"
 version = "0.1.0"
-source = "git+https://github.com/Lay3rLabs/avs-toolkit?tag=v0.1.2#bdc342892a3115711a61b7cf206ce7c529cb22e0"
+source = "git+https://github.com/Lay3rLabs/avs-toolkit.git?tag=v0.1.2#bdc342892a3115711a61b7cf206ce7c529cb22e0"
 dependencies = [
  "cosmwasm-std 2.1.4",
  "cw-storage-plus 2.0.0",
@@ -1176,7 +1176,25 @@ dependencies = [
 [[package]]
 name = "lavs-mock-operators"
 version = "0.1.0"
-source = "git+https://github.com/Lay3rLabs/avs-toolkit?tag=v0.1.2#bdc342892a3115711a61b7cf206ce7c529cb22e0"
+dependencies = [
+ "cosmwasm-schema 2.1.4",
+ "cosmwasm-std 2.1.4",
+ "cw-multi-test",
+ "cw-orch",
+ "cw-storage-plus 2.0.0",
+ "cw-utils 2.0.0",
+ "cw2 2.0.0",
+ "lavs-apis",
+ "lavs-orch",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "lavs-mock-operators"
+version = "0.1.0"
+source = "git+https://github.com/Lay3rLabs/avs-toolkit.git?tag=v0.1.2#bdc342892a3115711a61b7cf206ce7c529cb22e0"
 dependencies = [
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
@@ -1193,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "lavs-orch"
 version = "0.1.0"
-source = "git+https://github.com/Lay3rLabs/avs-toolkit?tag=v0.1.2#bdc342892a3115711a61b7cf206ce7c529cb22e0"
+source = "git+https://github.com/Lay3rLabs/avs-toolkit.git?tag=v0.1.2#bdc342892a3115711a61b7cf206ce7c529cb22e0"
 dependencies = [
  "cosmwasm-std 2.1.4",
  "cw-orch",
@@ -1202,7 +1220,26 @@ dependencies = [
 [[package]]
 name = "lavs-task-queue"
 version = "0.1.0"
-source = "git+https://github.com/Lay3rLabs/avs-toolkit?tag=v0.1.2#bdc342892a3115711a61b7cf206ce7c529cb22e0"
+dependencies = [
+ "cosmwasm-schema 2.1.4",
+ "cosmwasm-std 2.1.4",
+ "cw-multi-test",
+ "cw-orch",
+ "cw-storage-plus 2.0.0",
+ "cw-utils 2.0.0",
+ "cw2 2.0.0",
+ "lavs-apis",
+ "lavs-orch",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "lavs-task-queue"
+version = "0.1.0"
+source = "git+https://github.com/Lay3rLabs/avs-toolkit.git?tag=v0.1.2#bdc342892a3115711a61b7cf206ce7c529cb22e0"
 dependencies = [
  "cosmwasm-schema 2.1.4",
  "cosmwasm-std 2.1.4",
@@ -1219,8 +1256,8 @@ dependencies = [
 
 [[package]]
 name = "layer-wasi"
-version = "0.1.0"
-source = "git+https://github.com/Lay3rLabs/avs-toolkit#6037fe3f5a15403d4ee8e79059f144a794938d02"
+version = "0.1.1"
+source = "git+https://github.com/Lay3rLabs/avs-toolkit#08c1974e66990ba048df0dcbe1227a87db9fbafb"
 dependencies = [
  "serde",
  "serde_json",
@@ -1293,12 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"
@@ -1336,9 +1370,9 @@ dependencies = [
  "cw2 2.0.0",
  "lavs-apis",
  "lavs-helpers",
- "lavs-mock-operators",
+ "lavs-mock-operators 0.1.0 (git+https://github.com/Lay3rLabs/avs-toolkit.git?tag=v0.1.2)",
  "lavs-orch",
- "lavs-task-queue",
+ "lavs-task-queue 0.1.0 (git+https://github.com/Lay3rLabs/avs-toolkit.git?tag=v0.1.2)",
  "schemars",
  "serde",
  "serde_json",
@@ -1378,12 +1412,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -1458,7 +1486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -1870,9 +1898,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,26 @@ rust-version  = "1.78.0"
 [workspace.dependencies]
 anyhow        = "1"
 layer-wasi = { git = "https://github.com/Lay3rLabs/avs-toolkit", version = "0.1.0" }
+cosmwasm-std     = "2.1.4"
 serde = { version = "1.0.210", features = [ "derive" ] }
 serde_json = "1.0.128"
+
+lavs-mock-operators = { path = "contracts/mock-operators" }
+lavs-task-queue = { path = "contracts/task-queue" }
+oracle-verifier = { path = "contracts/oracle-verifier-example" }
+
+lavs-apis = { git = "https://github.com/Lay3rLabs/avs-toolkit.git", tag = "v0.1.2" }
+
+# mock-operator and task-queue
+cosmwasm-schema  = "2.1.4"
+cw-orch = "0.25.0"
+cw-orch-core = "2"
+cw-storage-plus  = "2.0.0"
+cw-utils         = "2.0.0"
+cw-controllers   = "2.0.0"
+cw2              = "2.0.0"
+schemars         = "0.8.17"
+thiserror        = "1.0.59"
+cw-multi-test = "0.20"
+lavs-arch = { git = "https://github.com/Lay3rLabs/avs-toolkit.git", tag = "v0.1.2" }
+lavs-orch = { git = "https://github.com/Lay3rLabs/avs-toolkit.git", tag = "v0.1.2" }

--- a/contracts/mock-operators/Cargo.toml
+++ b/contracts/mock-operators/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "lavs-mock-operators"
+version = "0.1.0"
+authors = ["Ethan Frey <ethanfrey@noreply.github.com>"]
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cosmwasm-schema = { workspace = true }
+cosmwasm-std = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw-utils = { workspace = true }
+cw2 = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+cw-orch = { workspace = true }
+lavs-apis = { workspace = true }
+
+[dev-dependencies]
+cw-multi-test = { workspace = true }
+lavs-orch = { workspace = true }
+cw-orch = { workspace = true }

--- a/contracts/mock-operators/README.md
+++ b/contracts/mock-operators/README.md
@@ -1,0 +1,35 @@
+# Mock Operators Contract
+
+This is a simple contract to simulate a set of operators with voting power for use with an AVS. It provides basic functionality to query voting power and total power at specific heights, as well as list all voters.
+
+## Actions
+
+### Instantiate
+
+The contract is instantiated with a list of operators and their voting powers:
+
+```rust
+pub struct InstantiateMsg {
+    pub operators: Vec<InstantiateOperator>,
+}
+
+pub struct InstantiateOperator {
+    pub addr: String,
+    pub voting_power: u32,
+}
+```
+
+During instantiation, the contract:
+- Validates operator addresses
+- Calculates the total voting power
+- Stores the configuration in the `CONFIG` item
+
+### Execute
+
+Currently, there are no execute messages implemented for this contract.
+
+### Query
+
+- `VotingPowerAtHeight`: Get the voting power of a specific address at a given height (or latest if not specified).
+- `TotalPowerAtHeight`: Get the total voting power at a given height (or latest if not specified).
+- `AllVoters`: List all voters (operators) and their voting powers.

--- a/contracts/mock-operators/src/bin/schema.rs
+++ b/contracts/mock-operators/src/bin/schema.rs
@@ -1,0 +1,11 @@
+use cosmwasm_schema::write_api;
+
+use lavs_mock_operators::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+    }
+}

--- a/contracts/mock-operators/src/contract.rs
+++ b/contracts/mock-operators/src/contract.rs
@@ -1,0 +1,113 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Uint128,
+};
+use cw2::set_contract_version;
+
+use crate::error::ContractError;
+use crate::msg::{ExecuteMsg, InstantiateMsg, InstantiateOperator, QueryMsg};
+use crate::state::{Config, OpInfo, CONFIG};
+
+// version info for migration info
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    let mut total_power = Uint128::zero();
+    let operators = msg
+        .operators
+        .into_iter()
+        .map(|InstantiateOperator { addr, voting_power }| {
+            let op = deps.api.addr_validate(&addr)?;
+            let power = Uint128::from(voting_power);
+            total_power += power;
+            Ok(OpInfo { op, power })
+        })
+        .collect::<StdResult<Vec<_>>>()?;
+    let config = Config {
+        operators,
+        total_power,
+    };
+    CONFIG.save(deps.storage, &config)?;
+
+    Ok(Response::new())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    unimplemented!()
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::VotingPowerAtHeight { address, height } => {
+            to_json_binary(&query::voting_power(deps, env, address, height)?)
+        }
+        QueryMsg::TotalPowerAtHeight { height } => {
+            to_json_binary(&query::total_power(deps, env, height)?)
+        }
+        QueryMsg::AllVoters {} => to_json_binary(&query::all_voters(deps, env)?),
+    }
+}
+
+// Although the queries take a height parameter, they don't use it to query historical data.
+// This doesn't matter here since we're just mocking the operators, and they don't change.
+mod query {
+    use super::*;
+
+    use lavs_apis::interfaces::voting::{
+        AllVotersResponse, TotalPowerResponse, VoterInfo, VotingPowerResponse,
+    };
+
+    pub fn voting_power(
+        deps: Deps,
+        env: Env,
+        address: String,
+        height: Option<u64>,
+    ) -> StdResult<VotingPowerResponse> {
+        let height = height.unwrap_or(env.block.height);
+        let addr = deps.api.addr_validate(&address)?;
+        let config = CONFIG.load(deps.storage)?;
+        let op = config.operators.iter().find(|op| op.op == addr);
+        let power = op.map(|op| op.power).unwrap_or_default();
+        Ok(VotingPowerResponse { power, height })
+    }
+
+    pub fn total_power(deps: Deps, env: Env, height: Option<u64>) -> StdResult<TotalPowerResponse> {
+        let height = height.unwrap_or(env.block.height);
+        let power = CONFIG.load(deps.storage)?.total_power;
+        let res = TotalPowerResponse { power, height };
+        Ok(res)
+    }
+
+    pub fn all_voters(deps: Deps, _env: Env) -> StdResult<AllVotersResponse> {
+        let config = CONFIG.load(deps.storage)?;
+        let voters = config
+            .operators
+            .into_iter()
+            .map(|op| VoterInfo {
+                power: op.power,
+                address: op.op.into_string(),
+            })
+            .collect();
+        Ok(AllVotersResponse { voters })
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/contracts/mock-operators/src/error.rs
+++ b/contracts/mock-operators/src/error.rs
@@ -1,0 +1,13 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+    // Add any other custom errors you like here.
+    // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
+}

--- a/contracts/mock-operators/src/interface.rs
+++ b/contracts/mock-operators/src/interface.rs
@@ -1,0 +1,28 @@
+use cw_orch::{interface, prelude::*};
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+type MigrateMsg = cosmwasm_std::Empty;
+
+pub const CONTRACT_ID: &str = env!("CARGO_PKG_NAME");
+
+#[interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg, id = CONTRACT_ID)]
+pub struct Contract;
+
+impl<Chain> Uploadable for Contract<Chain> {
+    /// Return the path to the wasm file corresponding to the contract
+    fn wasm(_chain: &ChainInfoOwned) -> WasmPath {
+        artifacts_dir_from_workspace!()
+            .find_wasm_path(CONTRACT_ID)
+            .unwrap()
+    }
+    /// Returns a CosmWasm contract wrapper
+    fn wrapper() -> Box<dyn MockContract<Empty>> {
+        Box::new(
+            ContractWrapper::new_with_empty(
+                crate::contract::execute,
+                crate::contract::instantiate,
+                crate::contract::query,
+            ), // .with_migrate(crate::contract::migrate),
+        )
+    }
+}

--- a/contracts/mock-operators/src/lib.rs
+++ b/contracts/mock-operators/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod contract;
+mod error;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;
+
+/// This is used for cw-orch
+#[cfg(not(target_arch = "wasm32"))]
+pub mod interface;
+
+#[cfg(test)]
+pub mod tests;

--- a/contracts/mock-operators/src/msg.rs
+++ b/contracts/mock-operators/src/msg.rs
@@ -1,0 +1,28 @@
+use cosmwasm_schema::cw_serde;
+
+// This pulls in the queries
+pub use lavs_apis::interfaces::voting::*;
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    pub operators: Vec<InstantiateOperator>,
+}
+
+#[cw_serde]
+pub struct InstantiateOperator {
+    /// The address of the operator
+    pub addr: String,
+    /// Their voting power
+    pub voting_power: u32,
+}
+
+impl InstantiateOperator {
+    pub fn new(addr: String, voting_power: u32) -> Self {
+        Self { addr, voting_power }
+    }
+}
+
+#[cw_serde]
+#[derive(cw_orch::ExecuteFns)]
+#[cw_orch(disable_fields_sorting)]
+pub enum ExecuteMsg {}

--- a/contracts/mock-operators/src/state.rs
+++ b/contracts/mock-operators/src/state.rs
@@ -1,0 +1,17 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, Uint128};
+use cw_storage_plus::Item;
+
+pub const CONFIG: Item<Config> = Item::new("config");
+
+#[cw_serde]
+pub struct Config {
+    pub operators: Vec<OpInfo>,
+    pub total_power: Uint128,
+}
+
+#[cw_serde]
+pub struct OpInfo {
+    pub op: Addr,
+    pub power: Uint128,
+}

--- a/contracts/mock-operators/src/tests/common.rs
+++ b/contracts/mock-operators/src/tests/common.rs
@@ -1,0 +1,70 @@
+use cosmwasm_std::Uint128;
+use cw_orch::environment::CwEnv;
+use cw_orch::prelude::*;
+
+use lavs_orch::{Addressable, AltSigner};
+
+use crate::interface::Contract;
+use crate::msg::{InstantiateMsg, InstantiateOperator, QueryMsgFns};
+
+pub const BECH_PREFIX: &str = "layer";
+
+pub fn setup<Chain: CwEnv>(chain: Chain, msg: InstantiateMsg) -> Contract<Chain> {
+    let contract = Contract::new(chain);
+    contract.upload().unwrap();
+    contract.instantiate(&msg, None, &[]).unwrap();
+    contract
+}
+
+/// Some basic tests to show it works.
+/// Doesn't test any real logic except for one instantiation
+pub fn happy_path<C>(chain: C)
+where
+    C: CwEnv + AltSigner,
+    C::Sender: Addressable,
+{
+    let op1 = chain.alt_signer(1);
+    let op2 = chain.alt_signer(2);
+    let op3 = chain.alt_signer(3);
+    let noop = chain.alt_signer(4);
+
+    let operators = vec![
+        InstantiateOperator::new(op1.addr().to_string(), 100),
+        InstantiateOperator::new(op2.addr().to_string(), 200),
+        InstantiateOperator::new(op3.addr().to_string(), 300),
+    ];
+
+    // put real message here
+    let msg = InstantiateMsg { operators };
+    let contract = setup(chain.clone(), msg);
+
+    // now query the total power
+    let total_power = contract.total_power_at_height(None).unwrap();
+    assert_eq!(total_power.power, Uint128::from(600u64));
+    assert_ne!(total_power.height, 0u64);
+
+    // now query the total power
+    let total_power = contract.total_power_at_height(Some(173)).unwrap();
+    assert_eq!(total_power.power, Uint128::from(600u64));
+    assert_eq!(total_power.height, 173u64);
+
+    // query the power of an operator
+    let total_power = contract
+        .voting_power_at_height(op2.addr().into_string(), Some(287))
+        .unwrap();
+    assert_eq!(total_power.power, Uint128::from(200u64));
+    assert_eq!(total_power.height, 287u64);
+
+    // query the power of an operator with None height (should return the current height, just ensure it works)
+    let total_power = contract
+        .voting_power_at_height(op1.addr().into_string(), None)
+        .unwrap();
+    assert_eq!(total_power.power, Uint128::from(100u64));
+
+    // query the power of a non-operator
+    let total_power = contract
+        .voting_power_at_height(noop.addr().into_string(), Some(287))
+        .unwrap();
+    assert_eq!(total_power.power, Uint128::zero());
+    assert_eq!(total_power.height, 287u64);
+}

--- a/contracts/mock-operators/src/tests/mod.rs
+++ b/contracts/mock-operators/src/tests/mod.rs
@@ -1,0 +1,2 @@
+mod common;
+mod multi;

--- a/contracts/mock-operators/src/tests/multi.rs
+++ b/contracts/mock-operators/src/tests/multi.rs
@@ -1,0 +1,9 @@
+use cw_orch::prelude::MockBech32;
+
+use super::common::BECH_PREFIX;
+
+#[test]
+fn happy_path_works() {
+    let chain = MockBech32::new(BECH_PREFIX);
+    super::common::happy_path(chain);
+}

--- a/contracts/task-queue/Cargo.toml
+++ b/contracts/task-queue/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "lavs-task-queue"
+version = "0.1.0"
+authors = ["Ethan Frey <ethanfrey@noreply.github.com>"]
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cosmwasm-schema = { workspace = true }
+cosmwasm-std = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = { workspace = true }
+cw-utils = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+cw-orch = { workspace = true }
+lavs-apis = { workspace = true }
+
+[dev-dependencies]
+cw-multi-test = { workspace = true }
+lavs-orch = { workspace = true }
+cw-orch = { workspace = true }

--- a/contracts/task-queue/README.md
+++ b/contracts/task-queue/README.md
@@ -1,0 +1,76 @@
+# Lay3r AVS Task Queue
+
+This is a simple contract to maintain a task queue for use with an AVS. This will become
+quite configurable over time, the general flow is:
+
+- Create Task
+- Complete Task
+- Timeout
+
+## Configuration
+
+The following configuration settings will be exposed:
+
+Requestor - an enum of:
+
+- Fixed Address (one address that can request)
+- Open Payment (any address with min fee)
+
+Verifier: Address of another contract that will verify any results and is the only address that
+can mark a request completed, along with the verified result.
+
+Min, Default, Max Timeout: The minimum, maximum, and default values of task timeouts. If the task creator
+doesn't provide a value, we will use the default. Otherwise, we assert the user-provided value is in the
+proscribed range.
+
+## Actions
+
+### Create Task
+
+This will be configurable to either one address that can create tasks (add to the queue),
+or a minimum fee. If the fee is set, anyone can add a task by paying the fee.
+
+### Complete Task
+
+Anyone can submit a proposed response to the verifier contract to complete a task. This will perform custom
+logic to ensure correctness and then call the task queue if it passes.
+
+### Timeout Task
+
+Anyone can call to mark a task as timed out if the block time has passed the task-specified timeout.
+(TODO: consider if the payment is refunded in such a case)
+
+## Queries
+
+- List open tasks (oldest first)
+- List closed tasks (most recently closed first)
+- Get Task info by id (included status and result if any)
+
+## Data
+
+Tasks will have `RequestData` as part of the structure and the verifiers will write `ResponseData`
+upon a successful validation. Both of these should be generics to allow the implementation of
+the task queue to define the specific types it supports.
+
+For MVP, we will use `serde::Value` to allow any arbitrary JSON for request and response. Later,
+we want to make this more specific.
+
+## Cw Orch Powered Testing
+
+Run the test cases on a real network.
+
+1. `(sudo) ./scripts/optimize.sh`
+2. `cd contracts/avs/tasks`
+3. `cargo run --example devnet --features dev`
+
+Ensure you have set `TEST_MNEMONIC` in `contracts/avs/tasks/.env` to an account with some tokens.
+
+## TODO
+
+We have a working MVP but need to make some improvements for this to be production-ready.
+Capturing a basic list of missing features here (bug fixes should be issues):
+
+- Efficient implementation of the list queries
+- Data cleanup (what tasks can be deleted? expired? completed after X second?)
+- More tests
+- Deployment script (along with other contracts)

--- a/contracts/task-queue/src/bin/schema.rs
+++ b/contracts/task-queue/src/bin/schema.rs
@@ -1,0 +1,11 @@
+use cosmwasm_schema::write_api;
+
+use lavs_task_queue::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+    }
+}

--- a/contracts/task-queue/src/contract.rs
+++ b/contracts/task-queue/src/contract.rs
@@ -1,0 +1,303 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
+use cw2::set_contract_version;
+
+use lavs_apis::interfaces::tasks as interface;
+use lavs_apis::tasks::{CustomExecuteMsg, CustomQueryMsg, TaskQueryMsg};
+
+use crate::error::ContractError;
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::msg::{RequestType, ResponseType, Status};
+use crate::state::{Config, Task, CONFIG, TASKS};
+
+// version info for migration info
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    let config = Config::validate(deps.as_ref(), msg)?;
+    CONFIG.save(deps.storage, &config)?;
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Api(api) => match api {
+            interface::TaskExecuteMsg::Complete { task_id, response } => {
+                execute::complete(deps, env, info, task_id, response)
+            }
+        },
+        ExecuteMsg::Custom(custom) => match custom {
+            CustomExecuteMsg::Create {
+                description,
+                timeout,
+                payload,
+            } => execute::create(deps, env, info, description, timeout, payload),
+            CustomExecuteMsg::Timeout { task_id } => execute::timeout(deps, env, info, task_id),
+        },
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
+    match msg {
+        QueryMsg::Api(api) => match api {
+            TaskQueryMsg::TaskStatus { id } => {
+                Ok(to_json_binary(&query::task_status(deps, env, id)?)?)
+            }
+        },
+        QueryMsg::Custom(custom) => match custom {
+            CustomQueryMsg::Task { id } => Ok(to_json_binary(&query::task(deps, env, id)?)?),
+            CustomQueryMsg::ListOpen { start_after, limit } => Ok(to_json_binary(
+                &query::list_open(deps, env, start_after, limit)?,
+            )?),
+            CustomQueryMsg::ListCompleted { start_after, limit } => Ok(to_json_binary(
+                &query::list_completed(deps, env, start_after, limit)?,
+            )?),
+            CustomQueryMsg::Config {} => Ok(to_json_binary(&query::config(deps, env)?)?),
+        },
+    }
+}
+
+mod execute {
+    use cw_utils::nonpayable;
+    use lavs_apis::id::TaskId;
+
+    use crate::state::{check_timeout, Timing};
+
+    use super::*;
+
+    pub fn create(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        description: String,
+        timeout: Option<u64>,
+        payload: RequestType,
+    ) -> Result<Response, ContractError> {
+        let mut config = CONFIG.load(deps.storage)?;
+        let timeout = check_timeout(&config.timeout, timeout)?;
+        config.requestor.check_requestor(&info)?;
+
+        let timing = Timing::new(&env, timeout);
+        let status = Status::new();
+        let task = Task {
+            description,
+            status,
+            timing,
+            payload,
+            result: None,
+        };
+        let task_id = config.next_id;
+        TASKS.save(deps.storage, task_id, &task)?;
+        config.next_id = TaskId::new(task_id.u64() + 1);
+        CONFIG.save(deps.storage, &config)?;
+
+        let res = Response::new()
+            .add_attribute("action", "create")
+            .add_attribute("task_id", task_id.to_string());
+        Ok(res)
+    }
+
+    pub fn complete(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        task_id: TaskId,
+        response: ResponseType,
+    ) -> Result<Response, ContractError> {
+        nonpayable(&info)?;
+
+        let config = CONFIG.load(deps.storage)?;
+        if info.sender != config.verifier {
+            return Err(ContractError::Unauthorized {});
+        }
+
+        // ensures it is open and not expired, then store response
+        let mut task = TASKS.load(deps.storage, task_id)?;
+        task.complete(&env, response)?;
+        TASKS.save(deps.storage, task_id, &task)?;
+
+        let res = Response::new()
+            .add_attribute("action", "completed")
+            .add_attribute("task_id", task_id.to_string());
+        Ok(res)
+    }
+
+    pub fn timeout(
+        deps: DepsMut,
+        env: Env,
+        info: MessageInfo,
+        task_id: TaskId,
+    ) -> Result<Response, ContractError> {
+        nonpayable(&info)?;
+
+        // ensures it is open and expired
+        let mut task = TASKS.load(deps.storage, task_id)?;
+        task.expire(&env)?;
+        TASKS.save(deps.storage, task_id, &task)?;
+
+        let res = Response::new()
+            .add_attribute("action", "expired")
+            .add_attribute("task_id", task_id.to_string());
+        Ok(res)
+    }
+}
+
+mod query {
+    use cw_storage_plus::Bound;
+    use lavs_apis::{id::TaskId, tasks::ConfigResponse};
+
+    use crate::msg::{
+        CompletedTaskOverview, ListCompletedResponse, ListOpenResponse, OpenTaskOverview,
+        TaskResponse, TaskStatusResponse,
+    };
+
+    use super::*;
+
+    pub fn task(deps: Deps, env: Env, id: TaskId) -> Result<TaskResponse, ContractError> {
+        let task = TASKS.load(deps.storage, id)?;
+        let status = task.validate_status(&env);
+
+        let r = TaskResponse {
+            id,
+            description: task.description,
+            status,
+            payload: task.payload,
+            result: task.result,
+        };
+        Ok(r)
+    }
+
+    pub fn task_status(
+        deps: Deps,
+        env: Env,
+        id: TaskId,
+    ) -> Result<TaskStatusResponse, ContractError> {
+        let task = TASKS.load(deps.storage, id)?;
+        let status = task.validate_status(&env).into();
+
+        let r = TaskStatusResponse {
+            id,
+            status,
+            created_height: task.timing.created_height,
+            created_time: task.timing.created_at,
+            expires_time: task.timing.expires_at,
+        };
+        Ok(r)
+    }
+
+    pub fn config(deps: Deps, _env: Env) -> Result<ConfigResponse, ContractError> {
+        let config = CONFIG.load(deps.storage)?;
+        let r = ConfigResponse {
+            requestor: config.requestor.into(),
+            timeout: config.timeout,
+            verifier: config.verifier.into_string(),
+        };
+        Ok(r)
+    }
+
+    // TODO: There should probably be a max page limit, but it's left unbound to keep the API simple for now
+    pub fn list_open(
+        deps: Deps,
+        env: Env,
+        start_after: Option<TaskId>,
+        limit: Option<u32>,
+    ) -> Result<ListOpenResponse, ContractError> {
+        let limit = limit.map(|v| v as usize).unwrap_or(usize::MAX);
+
+        let open = TASKS
+            .idx
+            .status
+            .prefix(Status::Open {}.as_str())
+            .range(
+                deps.storage,
+                None,
+                start_after.map(Bound::exclusive),
+                cosmwasm_std::Order::Descending,
+            )
+            .filter_map(|r| match r {
+                Ok((
+                    id,
+                    Task {
+                        payload,
+                        status: Status::Open {},
+                        timing,
+                        ..
+                    },
+                )) if timing.expires_at > env.block.time.seconds() => Some(Ok(OpenTaskOverview {
+                    id,
+                    expires: timing.expires_at,
+                    payload,
+                })),
+                Ok(_) => None,
+                Err(e) => Some(Err(e)),
+            })
+            .take(limit)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(ListOpenResponse { tasks: open })
+    }
+
+    pub fn list_completed(
+        deps: Deps,
+        _env: Env,
+        start_after: Option<TaskId>,
+        limit: Option<u32>,
+    ) -> Result<ListCompletedResponse, ContractError> {
+        let limit = limit.map(|v| v as usize).unwrap_or(usize::MAX);
+
+        let completed = TASKS
+            .idx
+            .status
+            .prefix(Status::Completed { completed: 0 }.as_str())
+            .range(
+                deps.storage,
+                None,
+                start_after.map(Bound::exclusive),
+                cosmwasm_std::Order::Descending,
+            )
+            .filter_map(|r| match r {
+                Ok((
+                    id,
+                    Task {
+                        result,
+                        status: Status::Completed { completed, .. },
+                        ..
+                    },
+                )) => match result {
+                    None => Some(Err(ContractError::MissingResultCompleted { id })),
+                    Some(result) => Some(Ok(CompletedTaskOverview {
+                        id,
+                        completed,
+                        result,
+                    })),
+                },
+                Ok(_) => None,
+                Err(e) => Some(Err(e.into())),
+            })
+            .take(limit)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(ListCompletedResponse { tasks: completed })
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/contracts/task-queue/src/error.rs
+++ b/contracts/task-queue/src/error.rs
@@ -1,0 +1,40 @@
+use cosmwasm_std::StdError;
+use cw_utils::PaymentError;
+use lavs_apis::id::TaskId;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("{0}")]
+    Payment(#[from] PaymentError),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("Timeout Info is invalid")]
+    InvalidTimeoutInfo,
+
+    #[error("Timeout is shorter than allowed minimum {0}")]
+    TimeoutTooShort(u64),
+
+    #[error("Timeout is longer than allowed maximum {0}")]
+    TimeoutTooLong(u64),
+
+    #[error("You need to pay at least {0} {1} to create a task")]
+    InsufficientPayment(u128, String),
+
+    #[error("Task is completed")]
+    TaskCompleted,
+
+    #[error("Task is expired")]
+    TaskExpired,
+
+    #[error("Task is not yet expired")]
+    TaskNotExpired,
+
+    #[error("Missing result for completed task {id}")]
+    MissingResultCompleted { id: TaskId },
+}

--- a/contracts/task-queue/src/interface.rs
+++ b/contracts/task-queue/src/interface.rs
@@ -1,0 +1,29 @@
+use cw_orch::{interface, prelude::*};
+
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+type MigrateMsg = cosmwasm_std::Empty;
+
+pub const CONTRACT_ID: &str = env!("CARGO_PKG_NAME");
+
+#[interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg, id = CONTRACT_ID)]
+pub struct Contract;
+
+impl<Chain> Uploadable for Contract<Chain> {
+    /// Return the path to the wasm file corresponding to the contract
+    fn wasm(_chain: &ChainInfoOwned) -> WasmPath {
+        artifacts_dir_from_workspace!()
+            .find_wasm_path(CONTRACT_ID)
+            .unwrap()
+    }
+
+    /// Returns a CosmWasm contract wrapper
+    fn wrapper() -> Box<dyn MockContract<Empty>> {
+        Box::new(
+            ContractWrapper::new_with_empty(
+                crate::contract::execute,
+                crate::contract::instantiate,
+                crate::contract::query,
+            ), // .with_migrate(crate::contract::migrate),
+        )
+    }
+}

--- a/contracts/task-queue/src/lib.rs
+++ b/contracts/task-queue/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod contract;
+mod error;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;
+
+/// This is used for cw-orch
+#[cfg(not(target_arch = "wasm32"))]
+pub mod interface;
+
+#[cfg(test)]
+pub mod tests;

--- a/contracts/task-queue/src/msg.rs
+++ b/contracts/task-queue/src/msg.rs
@@ -1,0 +1,2 @@
+// TODO: explicitly import the types we want?
+pub use lavs_apis::tasks::*;

--- a/contracts/task-queue/src/state.rs
+++ b/contracts/task-queue/src/state.rs
@@ -1,0 +1,187 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{Addr, Coin, Deps, Env, MessageInfo, StdError};
+use cw_storage_plus::{Index, IndexList, IndexedMap, Item, MultiIndex};
+use cw_utils::must_pay;
+
+use lavs_apis::id::TaskId;
+use lavs_apis::tasks::{Requestor, Status, TimeoutConfig};
+
+use crate::error::ContractError;
+use crate::msg::{self, InstantiateMsg, RequestType, ResponseType};
+
+pub const CONFIG: Item<Config> = Item::new("config");
+
+pub struct TaskIndexes<'a> {
+    pub status: MultiIndex<'a, &'a str, Task, TaskId>,
+}
+
+impl<'a> IndexList<Task> for TaskIndexes<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Task>> + '_> {
+        Box::new(std::iter::once(&self.status as &dyn Index<Task>))
+    }
+}
+
+pub const TASKS: IndexedMap<TaskId, Task, TaskIndexes<'static>> = IndexedMap::new(
+    "tasks",
+    TaskIndexes {
+        status: MultiIndex::new(|_, d: &Task| d.status.as_str(), "tasks", "tasks__status"),
+    },
+);
+
+#[cw_serde]
+pub struct Config {
+    pub next_id: TaskId,
+    pub requestor: RequestorConfig,
+    pub timeout: TimeoutConfig,
+    pub verifier: Addr,
+}
+
+impl Config {
+    pub fn validate(deps: Deps, input: InstantiateMsg) -> Result<Self, ContractError> {
+        let requestor = RequestorConfig::validate(deps, input.requestor)?;
+        let timeout = validate_timeout_info(input.timeout)?;
+        let verifier = deps.api.addr_validate(&input.verifier)?;
+        Ok(Config {
+            next_id: TaskId::new(1),
+            requestor,
+            timeout,
+            verifier,
+        })
+    }
+}
+
+#[cw_serde]
+pub enum RequestorConfig {
+    Fixed(Addr),
+    OpenPayment(Coin),
+}
+
+impl RequestorConfig {
+    pub fn validate(deps: Deps, input: msg::Requestor) -> Result<Self, StdError> {
+        match input {
+            msg::Requestor::Fixed(addr) => {
+                Ok(RequestorConfig::Fixed(deps.api.addr_validate(&addr)?))
+            }
+            msg::Requestor::OpenPayment(coin) => Ok(RequestorConfig::OpenPayment(coin)),
+        }
+    }
+
+    pub fn check_requestor(&self, info: &MessageInfo) -> Result<(), ContractError> {
+        match self {
+            RequestorConfig::Fixed(addr) => {
+                if info.sender != addr {
+                    return Err(ContractError::Unauthorized);
+                }
+            }
+            RequestorConfig::OpenPayment(needed) => {
+                let paid = must_pay(info, &needed.denom)?;
+                if paid < needed.amount {
+                    return Err(ContractError::InsufficientPayment(
+                        needed.amount.u128(),
+                        needed.denom.clone(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl From<RequestorConfig> for Requestor {
+    fn from(val: RequestorConfig) -> Self {
+        match val {
+            RequestorConfig::Fixed(addr) => Requestor::Fixed(addr.into_string()),
+            RequestorConfig::OpenPayment(coin) => Requestor::OpenPayment(coin),
+        }
+    }
+}
+
+pub fn validate_timeout_info(input: msg::TimeoutInfo) -> Result<TimeoutConfig, ContractError> {
+    let default = input.default;
+    let minimum = input.minimum.unwrap_or(default);
+    let maximum = input.maximum.unwrap_or(default);
+    if default < minimum || default > maximum || minimum > maximum {
+        return Err(ContractError::InvalidTimeoutInfo);
+    }
+    Ok(TimeoutConfig {
+        default,
+        minimum,
+        maximum,
+    })
+}
+
+pub fn check_timeout(config: &TimeoutConfig, timeout: Option<u64>) -> Result<u64, ContractError> {
+    match timeout {
+        Some(t) if t < config.minimum => Err(ContractError::TimeoutTooShort(config.minimum)),
+        Some(t) if t > config.maximum => Err(ContractError::TimeoutTooLong(config.maximum)),
+        Some(t) => Ok(t),
+        None => Ok(config.default),
+    }
+}
+
+#[cw_serde]
+pub struct Task {
+    pub description: String,
+    pub status: Status,
+    pub timing: Timing,
+    pub payload: RequestType,
+    pub result: Option<ResponseType>,
+}
+
+impl Task {
+    pub fn validate_status(&self, env: &Env) -> Status {
+        match self.status {
+            Status::Open {} if !self.timing.is_expired(env) => self.status.clone(),
+            Status::Expired {} | Status::Open {} => Status::Expired {},
+            Status::Completed { .. } => self.status.clone(),
+        }
+    }
+}
+
+#[cw_serde]
+pub struct Timing {
+    /// Creation in UNIX seconds
+    pub created_at: u64,
+    /// Expiration in UNIX seconds
+    pub expires_at: u64,
+    /// Creation in block height
+    pub created_height: u64,
+}
+
+impl Timing {
+    pub fn new(env: &Env, timeout: u64) -> Self {
+        Timing {
+            created_at: env.block.time.seconds(),
+            expires_at: env.block.time.seconds() + timeout,
+            created_height: env.block.height,
+        }
+    }
+
+    pub fn is_expired(&self, env: &Env) -> bool {
+        self.expires_at <= env.block.time.seconds()
+    }
+}
+
+impl Task {
+    pub fn complete(&mut self, env: &Env, result: ResponseType) -> Result<(), ContractError> {
+        match self.status {
+            Status::Open {} if !self.timing.is_expired(env) => {}
+            Status::Open {} | Status::Expired {} => return Err(ContractError::TaskExpired),
+            Status::Completed { .. } => return Err(ContractError::TaskCompleted),
+        };
+        self.status = Status::completed(env);
+        self.result = Some(result);
+        Ok(())
+    }
+
+    pub fn expire(&mut self, env: &Env) -> Result<(), ContractError> {
+        match self.status {
+            Status::Open {} if self.timing.is_expired(env) => {}
+            Status::Open {} => return Err(ContractError::TaskNotExpired),
+            Status::Expired {} => return Err(ContractError::TaskExpired),
+            Status::Completed { .. } => return Err(ContractError::TaskCompleted),
+        };
+        self.status = Status::Expired {};
+        Ok(())
+    }
+}

--- a/contracts/task-queue/src/tests/common.rs
+++ b/contracts/task-queue/src/tests/common.rs
@@ -1,0 +1,497 @@
+use cw_orch::environment::{ChainState, CwEnv, Environment, IndexResponse, QueryHandler};
+use cw_orch::prelude::*;
+use lavs_apis::id::TaskId;
+use lavs_apis::tasks::TaskStatus;
+use serde_json::json;
+
+use crate::error::ContractError;
+use crate::interface::Contract as TaskContract;
+use crate::msg::{
+    CompletedTaskOverview, InstantiateMsg, ListCompletedResponse, ListOpenResponse,
+    OpenTaskOverview, Requestor, Status, TimeoutInfo,
+};
+
+// FIXME: any way to get these as one import, rather than import all sub traits?
+// Maybe combining them in a super-trait?
+use crate::msg::{CustomExecuteMsgFns, CustomQueryMsgFns, TaskExecuteMsgFns, TaskQueryMsgFns};
+
+use lavs_orch::{Addressable, AltSigner};
+
+const VERIFIER_INDEX: u32 = 3;
+
+pub fn setup<Chain: CwEnv>(chain: Chain, msg: InstantiateMsg) -> TaskContract<Chain> {
+    let tasker = TaskContract::new(chain);
+    tasker.upload().unwrap();
+    tasker.instantiate(&msg, None, &[]).unwrap();
+    tasker
+}
+
+fn fixed_requestor<Chain>(chain: &Chain, timeout: u64) -> (TaskContract<Chain>, Chain::Sender)
+where
+    Chain: CwEnv + AltSigner,
+    Chain::Sender: Addressable,
+{
+    let verifier = chain.alt_signer(VERIFIER_INDEX);
+    let msg = InstantiateMsg {
+        requestor: Requestor::Fixed(chain.sender_addr().into()),
+        timeout: mock_timeout(timeout),
+        verifier: verifier.addr().into(),
+    };
+
+    let contract = setup(chain.clone(), msg);
+    (contract, verifier)
+}
+
+// This sets the chain signer to be the requestor
+// Pass another verifier in
+// (not sure how to generically get Addr from C::Sender for both mock and daemon)
+pub fn happy_path<C>(chain: C)
+where
+    C: CwEnv + AltSigner,
+    C::Sender: Addressable,
+{
+    let (contract, verifier) = fixed_requestor(&chain, 200);
+
+    contract.code_id().expect("Code not uploaded");
+    contract.address().expect("Contract not instantiated");
+
+    let payload_one = json! ({ "pair": ["eth", "usd"]});
+    let payload_two = json! ({ "pair": ["btc", "usd"]});
+
+    let result = json!({ "result": "success" });
+
+    // create two tasks
+    let one = make_task(&contract, "One", 300, &payload_one);
+    let start = get_time(contract.environment());
+    contract.environment().next_block().unwrap();
+    let two = make_task(&contract, "Two", 100, &payload_two);
+    let start_two = get_time(contract.environment());
+    contract.environment().next_block().unwrap();
+    assert_ne!(start, start_two);
+    assert_eq!(two, TaskId::new(one.u64() + 1));
+
+    // query for open tasks
+    let open = contract.list_open(None, None).unwrap();
+    assert_eq!(open.tasks.len(), 2);
+    let closed = contract.list_completed(None, None).unwrap();
+    assert_eq!(closed.tasks.len(), 0);
+
+    // fail to verify one task
+    let err = contract.complete(one, result.clone()).unwrap_err();
+    println!("Bad verfier error: {:?}", err);
+
+    // complete one task
+    contract
+        .call_as(&verifier)
+        .complete(one, result.clone())
+        .unwrap();
+    let end = get_time(contract.environment());
+
+    // check the list queries
+    let open = contract.list_open(None, None).unwrap();
+    assert_eq!(open.tasks.len(), 1);
+    let closed = contract.list_completed(None, None).unwrap();
+    assert_eq!(closed.tasks.len(), 1);
+
+    // check the details of the completed task
+    let details = contract.task(one).unwrap();
+    // We need to allow a little leeway, as start and end times may be off by a second
+    // Thus no equals comparision, but the destructuring test on status
+    assert_eq!(details.id, one);
+    assert_eq!(details.description, "One".to_string());
+    assert_eq!(details.payload, payload_one);
+    assert_eq!(details.result, Some(result));
+    match details.status {
+        Status::Completed { completed } => {
+            assert!(
+                completed >= end - 2 && completed <= end,
+                "completed: {}, end: {}",
+                completed,
+                end
+            );
+        }
+        _ => panic!("unexpected status"),
+    }
+}
+
+pub fn create<C>(chain: C)
+where
+    C: CwEnv + AltSigner,
+    C::Sender: Addressable,
+{
+    let (contract, verifier) = fixed_requestor(&chain, 200);
+    let payload = json! ({ "pair": ["eth", "usd"]});
+
+    let config = contract.config().unwrap();
+    assert_eq!(config.timeout.default, 200);
+    assert_eq!(config.timeout.minimum, 100);
+    assert_eq!(config.timeout.maximum, 400);
+    assert_eq!(
+        config.requestor,
+        Requestor::Fixed(chain.sender_addr().into())
+    );
+    assert_eq!(config.verifier, verifier.addr().into_string());
+
+    // Note: you need the root error to get that from the contract.
+    // {} will just show the method call,
+    // {:#} or {:?} will show the full error chain (but :# is nicer to read)
+    let err = contract
+        .create("Too Short".to_string(), Some(4), payload.clone(), &[])
+        .unwrap_err();
+    assert!(
+        err.root()
+            .to_string()
+            .contains(&ContractError::TimeoutTooShort(100).to_string()),
+        "Unexpected error: {}",
+        err.root()
+    );
+
+    let one = contract
+        .create("One".to_string(), None, payload.clone(), &[])
+        .unwrap();
+    let task_one = one.event_attr_value("wasm", "task_id").unwrap();
+    assert_eq!(task_one, "1");
+    let task_one: u64 = task_one.parse().unwrap();
+    assert_eq!(task_one, 1u64);
+
+    let two = contract
+        .create("Two".to_string(), None, payload.clone(), &[])
+        .unwrap();
+    let task_two = get_task_id(&two);
+    assert_eq!(task_two, TaskId::new(2u64));
+}
+
+// These measurements are a bit different between multi-test and golem.
+// Multi-test doesn't move a block until explicitly told, so only counts the next_blocks
+// Golem moves forward one block on each execution, so this is double the time in this case.
+// Also, the time to the contract is *after* the block moves forward.
+// Thus, we set offset to one block time, and block_time to 2 block times...
+pub fn list_open_queries_with_expiration<C>(chain: C, block_time: u64, offset: u64)
+where
+    C: CwEnv + AltSigner,
+    C::Sender: Addressable,
+{
+    let (contract, _verifier) = fixed_requestor(&chain, 200);
+    let payload_one = json! ({ "pair": ["eth", "usd"]});
+    let payload_two = json! ({ "pair": ["btc", "usd"]});
+    let payload_three = json! ({ "pair": ["atom", "eur"]});
+
+    let start = chain.block_info().unwrap().time.seconds();
+    let one = make_task(&contract, "One", 300, &payload_one);
+    chain.next_block().unwrap();
+    let two = make_task(&contract, "Two", 100, &payload_two);
+    chain.next_block().unwrap();
+    let three = make_task(&contract, "Two", None, &payload_three); // uses default of 200
+
+    let ListOpenResponse { tasks } = contract.list_open(None, None).unwrap();
+    assert_eq!(tasks.len(), 3);
+    assert_eq!(
+        tasks[0],
+        OpenTaskOverview {
+            id: three,
+            expires: start + 200 + 2 * block_time + offset, // we waited two blocks to create
+            payload: payload_three,
+        }
+    );
+    assert_eq!(
+        tasks[1],
+        OpenTaskOverview {
+            id: two,
+            expires: start + 100 + block_time + offset, // we waited one block to create
+            payload: payload_two,
+        }
+    );
+    assert_eq!(
+        tasks[2],
+        OpenTaskOverview {
+            id: one,
+            expires: start + 300 + offset,
+            payload: payload_one,
+        }
+    );
+
+    // now let's wait a bit so some expire
+    chain.wait_seconds(150).unwrap();
+    let ListOpenResponse { tasks } = contract.list_open(None, None).unwrap();
+    assert_eq!(tasks.len(), 2);
+    assert_eq!(tasks[0].id, three);
+    assert_eq!(tasks[1].id, one);
+
+    // and the next expiration
+    chain.wait_seconds(100).unwrap();
+    let ListOpenResponse { tasks } = contract.list_open(None, None).unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].id, one);
+
+    // and them all
+    chain.wait_seconds(100).unwrap();
+    let ListOpenResponse { tasks } = contract.list_open(None, None).unwrap();
+    assert_eq!(tasks.len(), 0);
+}
+
+pub fn completion_works<C>(chain: C)
+where
+    C: CwEnv + AltSigner,
+    C::Sender: Addressable,
+{
+    let (contract, verifier) = fixed_requestor(&chain, 200);
+    let payload = json! ({ "pair": ["eth", "usd"]});
+    let result = json! ({ "price": "1234.56"});
+
+    let one = make_task(&contract, "One", 300, &payload);
+    chain.next_block().unwrap();
+    let two = make_task(&contract, "Two", 100, &payload);
+
+    // list completed empty
+    let ListCompletedResponse { tasks } = contract.list_completed(None, None).unwrap();
+    assert_eq!(tasks.len(), 0);
+
+    // normal user cannot complete
+    let err = contract.complete(one, result.clone()).unwrap_err();
+    assert!(
+        err.root()
+            .to_string()
+            .contains(&ContractError::Unauthorized.to_string()),
+        "unexpected error: {}",
+        err.root(),
+    );
+
+    // verifier can complete
+    contract
+        .call_as(&verifier)
+        .complete(one, result.clone())
+        .unwrap();
+    let completion_time = chain.block_info().unwrap().time.seconds();
+    chain.next_block().unwrap();
+
+    // cannot complete already completed
+    let err = contract
+        .call_as(&verifier)
+        .complete(one, result.clone())
+        .unwrap_err();
+    assert!(
+        err.root()
+            .to_string()
+            .contains(&ContractError::TaskCompleted.to_string()),
+        "unexpected error: {}",
+        err.root(),
+    );
+
+    // cannot complete unknown task ids
+    let err = contract
+        .call_as(&verifier)
+        .complete(TaskId::new(two.u64() + 1), result.clone())
+        .unwrap_err();
+    assert!(err.root().to_string().contains("not found"));
+
+    // cannot complete expired
+    chain.wait_seconds(100).unwrap();
+    let err = contract
+        .call_as(&verifier)
+        .complete(two, result.clone())
+        .unwrap_err();
+    assert!(
+        err.root()
+            .to_string()
+            .contains(&ContractError::TaskExpired.to_string()),
+        "unexpected error: {}",
+        err.root(),
+    );
+
+    // list completed
+    let ListCompletedResponse { tasks } = contract.list_completed(None, None).unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(
+        tasks[0],
+        CompletedTaskOverview {
+            id: one,
+            completed: completion_time,
+            result,
+        }
+    );
+}
+
+pub fn task_status_works<C>(chain: C)
+where
+    C: CwEnv + AltSigner,
+    C::Sender: Addressable,
+{
+    let (contract, verifier) = fixed_requestor(&chain, 200);
+    let payload = json! ({ "pair": ["eth", "usd"]});
+    let result = json! ({ "price": "1234.56"});
+
+    let one = make_task(&contract, "One", 300, &payload);
+    chain.next_block().unwrap();
+    let two = make_task(&contract, "Two", 100, &payload);
+
+    // check open status
+    let status_one = contract.task_status(one).unwrap();
+    let status_two = contract.task_status(two).unwrap();
+    assert_eq!(status_one.created_time + 300, status_one.expires_time);
+    assert_eq!(status_two.created_time + 100, status_two.expires_time);
+    assert!(status_one.created_height < status_two.created_height);
+    assert_eq!(status_one.status, TaskStatus::Open);
+    assert_eq!(status_two.status, TaskStatus::Open);
+
+    // verifier can complete
+    contract
+        .call_as(&verifier)
+        .complete(one, result.clone())
+        .unwrap();
+    chain.next_block().unwrap();
+
+    // contract one changed
+    let status_one = contract.task_status(one).unwrap();
+    assert_eq!(status_one.status, TaskStatus::Completed);
+    // contract two unchanged
+    let status_two = contract.task_status(two).unwrap();
+    assert_eq!(status_two.status, TaskStatus::Open);
+
+    // expried contracts automatically update return value
+    chain.wait_seconds(200).unwrap();
+    // contract one unchanged
+    let status_one = contract.task_status(one).unwrap();
+    assert_eq!(status_one.status, TaskStatus::Completed);
+    // contract two expired
+    let status_two = contract.task_status(two).unwrap();
+    assert_eq!(status_two.status, TaskStatus::Expired);
+}
+
+pub fn task_pagination_works<C>(chain: C)
+where
+    C: CwEnv + AltSigner,
+    C::Sender: Addressable,
+{
+    let (contract, _verifier) = fixed_requestor(&chain, 1000);
+    let payload = json!({"pair": ["eth", "usd"]});
+
+    // Create 10 tasks with increasing timeouts
+    let mut created_tasks = Vec::new();
+    for i in 1..=10 {
+        let task_id = make_task(
+            &contract,
+            &format!("Task {}", i),
+            Some(1000 + i * 100),
+            &payload,
+        );
+        created_tasks.push(task_id);
+        chain.next_block().unwrap();
+    }
+
+    // Get the total number of open tasks
+    let ListOpenResponse {
+        tasks: all_open_tasks,
+    } = contract.list_open(None, None).unwrap();
+    let total_open_tasks = all_open_tasks.len();
+
+    // Test pagination with different limits
+    let test_cases = vec![2, 3, 5, 7, 10, 15];
+
+    for limit in test_cases {
+        let mut all_retrieved_tasks = Vec::new();
+        let mut start_after = None;
+
+        loop {
+            let ListOpenResponse { tasks } = contract.list_open(start_after, Some(limit)).unwrap();
+
+            if tasks.is_empty() {
+                break;
+            }
+
+            // Check that each page has the correct number of tasks
+            assert!(tasks.len() <= limit as usize, "Page size exceeds limit");
+
+            // Check that there's no overlap with previously retrieved tasks
+            for task in &tasks {
+                assert!(
+                    !all_retrieved_tasks.contains(&task.id),
+                    "Task {} appeared in multiple pages",
+                    task.id
+                );
+            }
+
+            // If it's not the first page, check that the first task of this page has an older task id.
+            // Newest tasks are retrieved first.
+            if let Some(last_task_id) = start_after {
+                assert!(
+                    tasks[0].id < last_task_id,
+                    "First task of new page ({:?}) should have older task id ({:?})",
+                    tasks[0].id,
+                    last_task_id
+                );
+            }
+
+            all_retrieved_tasks.extend(tasks.iter().map(|t| t.id));
+            start_after = tasks.last().map(|t| t.id);
+        }
+
+        // Check total number of tasks retrieved
+        assert_eq!(
+            all_retrieved_tasks.len(),
+            total_open_tasks,
+            "Number of tasks retrieved ({}) doesn't match total open tasks ({})",
+            all_retrieved_tasks.len(),
+            total_open_tasks
+        );
+
+        // Check that all created tasks (that are still open) are in the retrieved tasks
+        for task_id in &created_tasks {
+            if all_open_tasks.iter().any(|t| t.id == *task_id) {
+                assert!(
+                    all_retrieved_tasks.contains(task_id),
+                    "Created task {:?} is missing from retrieved tasks",
+                    task_id
+                );
+            }
+        }
+    }
+
+    // Test with no limit (should return all open tasks)
+    let ListOpenResponse { tasks } = contract.list_open(None, None).unwrap();
+    assert_eq!(
+        tasks.len(),
+        total_open_tasks,
+        "Should return all open tasks when no limit is specified"
+    );
+}
+
+#[track_caller]
+pub fn get_time(chain: &impl QueryHandler) -> u64 {
+    chain.block_info().unwrap().time.seconds()
+}
+
+#[track_caller]
+pub fn make_task<C: ChainState + TxHandler>(
+    contract: &TaskContract<C>,
+    name: &str,
+    timeout: impl Into<Option<u64>>,
+    payload: &serde_json::Value,
+) -> TaskId {
+    let res = contract
+        .create(name.to_string(), timeout.into(), payload.clone(), &[])
+        .unwrap();
+    get_task_id(&res)
+}
+
+// Note: return types for methods depends on the chain...
+// mock -> abstract_cw_multi_test::AppResponse
+// osmosis test tube -> abstract_cw_multi_test::AppResponse
+// daemon -> cw_orch::daemon::CosmTxResponse
+//
+// Note: both implement cw_orch::environment::IndexResponse
+#[track_caller]
+pub fn get_task_id(res: &impl IndexResponse) -> TaskId {
+    res.event_attr_value("wasm", "task_id")
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+// sets up a range around 50% to 200% of the default timeout
+pub fn mock_timeout(default: u64) -> TimeoutInfo {
+    TimeoutInfo {
+        default,
+        minimum: Some(default / 2),
+        maximum: Some(default * 2),
+    }
+}

--- a/contracts/task-queue/src/tests/mod.rs
+++ b/contracts/task-queue/src/tests/mod.rs
@@ -1,0 +1,2 @@
+mod common;
+mod multi;

--- a/contracts/task-queue/src/tests/multi.rs
+++ b/contracts/task-queue/src/tests/multi.rs
@@ -1,0 +1,72 @@
+// use cw_orch::environment::IndexResponse;
+use cw_orch::prelude::*;
+
+use crate::interface::Contract;
+use crate::msg::{InstantiateMsg, Requestor, TimeoutInfo};
+
+// TODO: shared variable
+const BECH_PREFIX: &str = "layer";
+
+// Note: there is an assumption of 5 second blocks in the test framework
+// let's make this clear in the tests
+const BLOCK_TIME: u64 = 5;
+
+#[test]
+fn happy_path_works() {
+    let chain = MockBech32::new(BECH_PREFIX);
+    super::common::happy_path(chain);
+}
+
+#[test]
+fn crate_works() {
+    let chain = MockBech32::new(BECH_PREFIX);
+    super::common::create(chain);
+}
+
+#[test]
+fn list_open_queries_with_expiration() {
+    let chain = MockBech32::new(BECH_PREFIX);
+    super::common::list_open_queries_with_expiration(chain, BLOCK_TIME, 0);
+}
+
+#[test]
+fn completion_works() {
+    let chain = MockBech32::new(BECH_PREFIX);
+    super::common::completion_works(chain);
+}
+
+#[test]
+fn task_status() {
+    let chain = MockBech32::new(BECH_PREFIX);
+    super::common::task_status_works(chain);
+}
+
+#[test]
+fn task_pagination() {
+    let chain = MockBech32::new(BECH_PREFIX);
+    super::common::task_pagination_works(chain);
+}
+
+/// This is the simplest, most explicit test to bootstrap, before importing from common
+#[test]
+fn sanity_check() {
+    let mock = MockBech32::new(BECH_PREFIX);
+    let tasker = Contract::new(mock.clone());
+    let code_id = tasker.upload().unwrap().uploaded_code_id().unwrap();
+    assert_eq!(code_id, tasker.code_id().unwrap());
+
+    let verifier = mock.addr_make("verifier");
+
+    let msg = InstantiateMsg {
+        requestor: Requestor::Fixed(mock.sender_addr().into()),
+        timeout: TimeoutInfo {
+            default: 3600,
+            minimum: None,
+            maximum: None,
+        },
+        verifier: verifier.to_string(),
+    };
+    let init_res = tasker.instantiate(&msg, None, &[]).unwrap();
+    let contract_addr = init_res.instantiated_contract_address().unwrap();
+    assert_eq!(contract_addr, tasker.address().unwrap());
+}


### PR DESCRIPTION
In order to implement https://github.com/Lay3rLabs/example-avs-oracle/issues/3 with the use of CLI, I need to be able to deploy those two smart contracts as well.
The simplest way is to just copy them over for the test use.