### PR TITLE
set the namespace for publishing to examples

### DIFF
--- a/wasi/oracle-example/Cargo.toml
+++ b/wasi/oracle-example/Cargo.toml
@@ -24,7 +24,7 @@ strip = true
 lto = true
 
 [package.metadata.component]
-package = "lay3r:oracle-example"
+package = "lay3r-examples:oracle-example"
 target = "lay3r:avs/task-queue@0.3.0"
 
 [package.metadata.component.dependencies]


### PR DESCRIPTION
Shouldn't break anything in the docs. Small change so that it can be published to `lay3r-examples` namespace.